### PR TITLE
Add uniquename1 to Backstage Software Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,13 +1,9 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: "uniquename"
-  description: "asdfasdf"
-  annotations:
-    github.com/project-slug: aretli/uniquename1
-    backstage.io/techdocs-ref: dir:.
-    sonarqube.org/project-key: anthony
-spec:
-  type: website
-  lifecycle: experimental
-  owner: "group:default/demo-team"
+  kind: Component
+  metadata:
+    name: uniquename1
+  spec:
+    type: service
+    lifecycle: experimental
+    owner: anthonyretliorganization/demo-team
+    system: example


### PR DESCRIPTION

## TL;DR

This pull request registers uniquename1, as a component in our Backstage Software Catalog. 
It lists our team, anthonyretliorganization/demo-team, as the owners of this component.
To add this component to the Backstage Software Catalog, follow the steps here → http://localhost/catalog-import

## What is Backstage?

[Backstage](https://backstage.io/) is an open platform for building developer portals. Powered by a centralized 
software catalog, Backstage restores order to your microservices and infrastructure and enables your product teams 
to ship high-quality code quickly without compromising autonomy.

Backstage unifies all your infrastructure tooling, services, and documentation to create a streamlined development environment from end to end.

[![What is Backstage? (Explainer Video)](https://img.youtube.com/vi/85TQEpNCaU0/hqdefault.jpg)([https://youtu.be/85TQEpNCaU0])]
